### PR TITLE
rename bower file for proper case

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "bower-parseUri",
+  "name": "bower-parseuri",
   "version": "1.2.2",
   "main": "parseuri.js"
 }


### PR DESCRIPTION
The name that is registered with bower is all lower case and if you try to include with bower-parseUri it is not found.
